### PR TITLE
Evitar mutaciones

### DIFF
--- a/src/main/java/com/danimaniarqsoft/brain/tasks/GenerateReportTask.java
+++ b/src/main/java/com/danimaniarqsoft/brain/tasks/GenerateReportTask.java
@@ -14,11 +14,11 @@ import com.danimaniarqsoft.brain.util.UrlPd;
 
 import javafx.concurrent.Task;
 
-public class GenerateReportTask extends Task<Boolean> {
+public final class GenerateReportTask extends Task<Boolean> {
 	private static final Logger LOGGER = LoggerFactory.getLogger(GenerateReportTask.class);
 
-	private int selectedIndex;
-	private UrlPd urlPd;
+	private final int selectedIndex;
+	private final UrlPd urlPd;
 
 	public GenerateReportTask(int selectedIndex, UrlPd urlPd) {
 		this.selectedIndex = selectedIndex;
@@ -26,7 +26,7 @@ public class GenerateReportTask extends Task<Boolean> {
 	}
 
 	@Override
-	protected Boolean call() throws Exception {
+	protected final Boolean call() throws Exception {
 		try {
 			if (selectedIndex == Constants.FIST_SELECTION) {
 				DateUtils.setEn(false);


### PR DESCRIPTION
Las variables miembro deben ser final para evitar mutaciones accidentales, lo mismo para clases y métodos, si el diseño cambia se puede evaluar si cambiar el modificador de acceso.
